### PR TITLE
Added .editorconfig for enforcing encodings/line endings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.{json,py}]
+charset = utf-8
+indent_style = space
+indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -7,7 +7,7 @@ root = true
 end_of_line = lf
 insert_final_newline = true
 
-[*.{json,py}]
+[*.{json,py,toml}]
 charset = utf-8
 indent_style = space
 indent_size = 4


### PR DESCRIPTION
Support for http://editorconfig.org/

Support is built-in on Jetbrains IDEs and is supported on most editors. Helps maintain consistent file encodings, indentation, and line endings across editors.