### PR TITLE
Added Pipfile for pipenv support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ skeletons/*
 __pycache__/*
 test-files/*
 venv/*
+Pipfile.lock

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,15 @@
+[[source]]
+url = 'https://pypi.python.org/simple'
+verify_ssl = true
+name = 'pypi'
+
+[requires]
+python_version = '3.6'
+
+[packages]
+attrs='==17.4.0'
+requests='==2.18.4'
+toml='==0.9.4'
+
+[dev-packages]
+py={version='==1.5.2'}


### PR DESCRIPTION
If we want to move to using the `pipenv` tool for managing environments and pip, we'll need a `Pipfile`.